### PR TITLE
Prevent ComposedComponent from appearing before redirect

### DIFF
--- a/client/src/containers/RequireAuth.js
+++ b/client/src/containers/RequireAuth.js
@@ -20,7 +20,7 @@ export default function(ComposedComponent) {
     }
 
     render() {
-      return <ComposedComponent {...this.props} />
+      return this.props.authenticated ? <ComposedComponent {...this.props} /> : null
     }
   }
 


### PR DESCRIPTION
There is a security issue when ComposedComponent appears for a second before redirect when the user is unauthenticated.